### PR TITLE
Added metadata preservation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,98 @@
+# ---- build stage -------------------------------------------------
+FROM ubuntu:24.04 AS build
+ARG ZIG_VERSION=0.15.2
+ARG LIBAVIF_VERSION=1.3.0
+ARG LIBWEBP_VERSION=1.4.0
+ARG LIBJPEG_TURBO_VERSION=3.1.3
+ARG LIBSPNG_VERSION=0.7.4
+ARG LIBAOM_VERSION=v3.13.1
+ARG SVTAV1_VERSION=v3.1.2
+ARG DAV1D_VERSION=1.5.0
+ARG RAV1E_VERSION=0.8.1
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential curl cmake git wget ca-certificates xz-utils \
+    pkg-config zlib1g-dev nasm libheif-dev libpng-dev meson \
+    libstdc++6 libgav1-dev libgcc-s1 gcc-14-base \
+    && rm -rf /var/lib/apt/lists/*
+
+# Zig 
+RUN curl https://ziglang.org/download/${ZIG_VERSION}/zig-$(uname -m)-linux-${ZIG_VERSION}.tar.xz -o zig-linux.tar.xz && \
+    mkdir /opt/zig && \
+    tar xf zig-linux.tar.xz -C /opt/zig --strip-components=1
+ENV PATH="/opt/zig:${PATH}"
+
+WORKDIR /build
+ENV INSTALL_PREFIX=/build/install
+ENV PKG_CONFIG_PATH=${INSTALL_PREFIX}/lib/pkgconfig:${INSTALL_PREFIX}/lib/x86_64-linux-gnu/pkgconfig
+ENV CFLAGS="-I/build/install/include"
+ENV LDFLAGS="-L/build/install/lib -L/usr/lib/x86_64-linux-gnu"
+RUN mkdir -p ${INSTALL_PREFIX}
+
+# libjpeg-turbo
+RUN wget -q https://github.com/libjpeg-turbo/libjpeg-turbo/releases/download/${LIBJPEG_TURBO_VERSION}/libjpeg-turbo-${LIBJPEG_TURBO_VERSION}.tar.gz \
+ && tar -xzf libjpeg-turbo-${LIBJPEG_TURBO_VERSION}.tar.gz \
+ && cmake -S libjpeg-turbo-${LIBJPEG_TURBO_VERSION} -B jt -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=Release -DENABLE_SHARED=OFF -DENABLE_STATIC=ON \
+ && cmake --build jt -j$(nproc) && cmake --install jt
+
+# libspng
+RUN wget -q https://github.com/randy408/libspng/archive/refs/tags/v${LIBSPNG_VERSION}.tar.gz -O libspng.tgz \
+ && tar -xzf libspng.tgz \
+ && cmake -S libspng-${LIBSPNG_VERSION} -B spng -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF -DSPNG_STATIC=ON \
+ && cmake --build spng -j$(nproc) && cmake --install spng \
+ && ln -s ${INSTALL_PREFIX}/lib/libspng_static.a ${INSTALL_PREFIX}/lib/libspng.a
+
+# libwebp
+RUN wget -q https://github.com/webmproject/libwebp/archive/refs/tags/v${LIBWEBP_VERSION}.tar.gz -O libwebp.tgz \
+ && tar -xzf libwebp.tgz \
+ && cmake -S libwebp-${LIBWEBP_VERSION} -B webp -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DBUILD_SHARED_LIBS=OFF \
+ && cmake --build webp -j$(nproc) && cmake --install webp
+
+# dav1d
+RUN wget -q https://code.videolan.org/videolan/dav1d/-/archive/${DAV1D_VERSION}/dav1d-${DAV1D_VERSION}.tar.gz -O dav1d.tgz \
+ && tar -xzf dav1d.tgz \
+ && meson setup dav1d-${DAV1D_VERSION}/build dav1d-${DAV1D_VERSION} --prefix=${INSTALL_PREFIX} --buildtype=release --default-library=static \
+ && meson compile -C dav1d-${DAV1D_VERSION}/build && meson install -C dav1d-${DAV1D_VERSION}/build
+
+# rav1e
+RUN wget -q https://github.com/xiph/rav1e/releases/download/v${RAV1E_VERSION}/librav1e-${RAV1E_VERSION}-linux-generic.tar.gz -O rav1e.tgz \
+ && mkdir librav1e && tar -xzf rav1e.tgz -C librav1e \
+ && cp -r librav1e/include/* ${INSTALL_PREFIX}/include/ \
+ && cp -P librav1e/lib/*.a ${INSTALL_PREFIX}/lib/ \
+ && cp -P librav1e/lib/pkgconfig/* ${INSTALL_PREFIX}/lib/pkgconfig/
+
+# SVT-AV1
+RUN wget -q https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/${SVTAV1_VERSION}/SVT-AV1-${SVTAV1_VERSION}.tar.gz -O svtav1.tgz \
+ && tar -xzf svtav1.tgz \
+ && cmake -S SVT-AV1-${SVTAV1_VERSION} -B svtav1 -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
+ && cmake --build svtav1 -j$(nproc) && cmake --install svtav1
+
+# libavif
+RUN wget -q https://github.com/AOMediaCodec/libavif/archive/refs/tags/v${LIBAVIF_VERSION}.tar.gz -O libavif.tgz \
+ && tar -xzf libavif.tgz \
+ && cmake -S libavif-${LIBAVIF_VERSION} -B avif \
+    -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DAVIF_CODEC_AOM=LOCAL -DAVIF_AOM_GIT_TAG=${LIBAOM_VERSION} \
+    -DAVIF_CODEC_DAV1D=LOCAL \
+    -DAVIF_CODEC_RAV1E=SYSTEM \
+    -DAVIF_CODEC_SVT=LOCAL \
+    -DAVIF_LIBYUV=LOCAL \
+    -DAVIF_BUILD_APPS=ON \
+ && cmake --build avif -j$(nproc) && cmake --install avif
+
+# oavif
+ADD . /build/oavif
+WORKDIR /build/oavif
+RUN zig build --release=fast --search-prefix ${INSTALL_PREFIX} -Drav1e=true
+
+# ---- final stage -------------------------------------------------
+FROM gcr.io/distroless/cc-debian12:nonroot
+COPY --from=build /build/oavif/zig-out/bin/oavif /oavif
+COPY --from=build /build/install/ /build
+COPY --from=build /lib/x86_64-linux-gnu/libgcc_s.so.1 /lib/x86_64-linux-gnu/
+COPY --from=build /usr/lib/x86_64-linux-gnu/libstdc++.so.6 /usr/lib/x86_64-linux-gnu/
+USER nonroot
+ENTRYPOINT ["/oavif"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,19 +55,6 @@ RUN wget -q https://code.videolan.org/videolan/dav1d/-/archive/${DAV1D_VERSION}/
  && meson setup dav1d-${DAV1D_VERSION}/build dav1d-${DAV1D_VERSION} --prefix=${INSTALL_PREFIX} --buildtype=release --default-library=static \
  && meson compile -C dav1d-${DAV1D_VERSION}/build && meson install -C dav1d-${DAV1D_VERSION}/build
 
-# rav1e
-RUN wget -q https://github.com/xiph/rav1e/releases/download/v${RAV1E_VERSION}/librav1e-${RAV1E_VERSION}-linux-generic.tar.gz -O rav1e.tgz \
- && mkdir librav1e && tar -xzf rav1e.tgz -C librav1e \
- && cp -r librav1e/include/* ${INSTALL_PREFIX}/include/ \
- && cp -P librav1e/lib/*.a ${INSTALL_PREFIX}/lib/ \
- && cp -P librav1e/lib/pkgconfig/* ${INSTALL_PREFIX}/lib/pkgconfig/
-
-# SVT-AV1
-RUN wget -q https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/${SVTAV1_VERSION}/SVT-AV1-${SVTAV1_VERSION}.tar.gz -O svtav1.tgz \
- && tar -xzf svtav1.tgz \
- && cmake -S SVT-AV1-${SVTAV1_VERSION} -B svtav1 -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
- && cmake --build svtav1 -j$(nproc) && cmake --install svtav1
-
 # libavif
 RUN wget -q https://github.com/AOMediaCodec/libavif/archive/refs/tags/v${LIBAVIF_VERSION}.tar.gz -O libavif.tgz \
  && tar -xzf libavif.tgz \
@@ -77,8 +64,8 @@ RUN wget -q https://github.com/AOMediaCodec/libavif/archive/refs/tags/v${LIBAVIF
     -DBUILD_SHARED_LIBS=OFF \
     -DAVIF_CODEC_AOM=LOCAL -DAVIF_AOM_GIT_TAG=${LIBAOM_VERSION} \
     -DAVIF_CODEC_DAV1D=LOCAL \
-    -DAVIF_CODEC_RAV1E=SYSTEM \
-    -DAVIF_CODEC_SVT=LOCAL \
+    -DAVIF_CODEC_RAV1E=OFF \
+    -DAVIF_CODEC_SVT=OFF \
     -DAVIF_LIBYUV=LOCAL \
     -DAVIF_BUILD_APPS=ON \
  && cmake --build avif -j$(nproc) && cmake --install avif
@@ -86,7 +73,7 @@ RUN wget -q https://github.com/AOMediaCodec/libavif/archive/refs/tags/v${LIBAVIF
 # oavif
 ADD . /build/oavif
 WORKDIR /build/oavif
-RUN zig build --release=fast --search-prefix ${INSTALL_PREFIX} -Drav1e=true
+RUN zig build --release=fast --search-prefix ${INSTALL_PREFIX}
 
 # ---- final stage -------------------------------------------------
 FROM gcr.io/distroless/cc-debian12:nonroot

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+IMAGE=oavif-build
+
+binary: docker-build
+	mkdir -p bin
+	docker create --name tmp $(IMAGE)
+	docker cp tmp:/oavif bin/oavif
+	docker rm tmp
+
+docker-build:
+	docker build --progress=plain -t $(IMAGE) .
+
+clean:
+	rm -f bin
+	docker rmi $(IMAGE) || true

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ The `oavif` binary will be emitted to `zig-out/bin`. To install system-wide on m
 zig build --release=fast --prefix /usr/local
 ```
 
+>[!tip]
+> If your libavif library contains rav1e like in the `Dockerfile` you can use the `-Drav1e=true` option
+> for it to be properly linked 
+
 ### Docker
 
 A multi-stage Dockerfile is provided to build a fully static `oavif` binary in a controlled environment.

--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ The `oavif` binary will be emitted to `zig-out/bin`. To install system-wide on m
 zig build --release=fast --prefix /usr/local
 ```
 
->[!tip]
-> If your libavif library contains rav1e like in the `Dockerfile` you can use the `-Drav1e=true` option
-> for it to be properly linked 
-
 ### Docker
 
 A multi-stage Dockerfile is provided to build a fully static `oavif` binary in a controlled environment.

--- a/build.zig
+++ b/build.zig
@@ -30,9 +30,6 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    // Optional build option, support for rav1e av1 encoder, add with -Drav1e=true
-    const use_rav1e = b.option(bool, "rav1e", "Include rav1e support") orelse false;
-
     // oavif
     const bin = b.addExecutable(.{
         .name = "oavif",
@@ -42,7 +39,6 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .strip = strip,
             .link_libc = true,
-            .link_libcpp = true,
         }),
     });
     bin.root_module.addOptions("build_opts", options);
@@ -61,8 +57,5 @@ pub fn build(b: *std.Build) void {
     bin.root_module.linkSystemLibrary("spng", .{ .preferred_link_mode = .static });
     bin.root_module.linkSystemLibrary("heif", .{ .preferred_link_mode = .static });
 
-    if (use_rav1e) {
-        bin.root_module.linkSystemLibrary("rav1e", .{ .preferred_link_mode = .static });
-    }
     b.installArtifact(bin);
 }

--- a/build.zig
+++ b/build.zig
@@ -30,6 +30,9 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
+    // Optional build option, support for rav1e av1 encoder, add with -Drav1e=true
+    const use_rav1e = b.option(bool, "rav1e", "Include rav1e support") orelse false;
+
     // oavif
     const bin = b.addExecutable(.{
         .name = "oavif",
@@ -39,6 +42,7 @@ pub fn build(b: *std.Build) void {
             .optimize = optimize,
             .strip = strip,
             .link_libc = true,
+            .link_libcpp = true,
         }),
     });
     bin.root_module.addOptions("build_opts", options);
@@ -52,9 +56,13 @@ pub fn build(b: *std.Build) void {
     // system decoder libs
     bin.root_module.linkSystemLibrary("jpeg", .{ .preferred_link_mode = .static });
     bin.root_module.linkSystemLibrary("webp", .{ .preferred_link_mode = .static });
+    bin.root_module.linkSystemLibrary("webpmux", .{ .preferred_link_mode = .static });
     bin.root_module.linkSystemLibrary("avif", .{ .preferred_link_mode = .static });
     bin.root_module.linkSystemLibrary("spng", .{ .preferred_link_mode = .static });
     bin.root_module.linkSystemLibrary("heif", .{ .preferred_link_mode = .static });
 
+    if (use_rav1e) {
+        bin.root_module.linkSystemLibrary("rav1e", .{ .preferred_link_mode = .static });
+    }
     b.installArtifact(bin);
 }

--- a/src/io.zig
+++ b/src/io.zig
@@ -5,6 +5,7 @@ const c = @cImport({
     @cInclude("spng.h");
     @cInclude("jpeglib.h");
     @cInclude("webp/decode.h");
+    @cInclude("webp/mux.h");
     @cInclude("avif/avif.h");
     @cInclude("libheif/heif.h");
 });
@@ -54,12 +55,14 @@ pub const Image = struct {
     hbd: bool, // high bit depth (16-bit)
     data: []u8, // interleaved, row-major
     icc: ?[]u8 = null, // ICC color profile data
+    exif: ?[]u8 = null,
+    xmp: ?[]u8 = null,
 
     pub fn deinit(img: *Image, allocator: std.mem.Allocator) void {
         allocator.free(img.data);
-        if (img.icc) |icc|
-            allocator.free(icc);
-        img.* = undefined;
+        if (img.icc) |icc| allocator.free(icc);
+        if (img.exif) |exif| allocator.free(exif);
+        if (img.xmp) |xmp| allocator.free(xmp);
     }
 
     pub fn toRGB8(img: *Image, allocator: std.mem.Allocator) ![]u8 {
@@ -227,7 +230,8 @@ pub fn loadJPEG(allocator: std.mem.Allocator, path: []const u8) !Image {
     defer c.jpeg_destroy_decompress(&cinfo);
 
     c.jpeg_stdio_src(&cinfo, file_ptr);
-    c.jpeg_save_markers(&cinfo, c.JPEG_APP0 + 2, 0xFFFF);
+    c.jpeg_save_markers(&cinfo, c.JPEG_APP0 + 1, 0xFFFF); // APP1 for EXIF and XMP
+    c.jpeg_save_markers(&cinfo, c.JPEG_APP0 + 2, 0xFFFF); // APP2 for ICC
 
     if (c.jpeg_read_header(&cinfo, c.TRUE) != c.JPEG_HEADER_OK)
         return error.InvalidJPEGHeader;
@@ -241,6 +245,25 @@ pub fn loadJPEG(allocator: std.mem.Allocator, path: []const u8) !Image {
             @memcpy(icc_profile.?, icc_data_ptr[0..icc_data_len]);
             c.free(icc_data_ptr);
         };
+
+    var exif_data: ?[]u8 = null;
+    var xmp_data: ?[]u8 = null;
+    var marker = cinfo.marker_list;
+    while (marker != null) : (marker = marker.*.next) {
+        if (marker.*.marker == c.JPEG_APP0 + 1) {
+            const marker_data = marker.*.data[0..marker.*.data_length];
+            // EXIF: starts with "Exif\0\0"
+            if (marker_data.len > 6 and std.mem.eql(u8, marker_data[0..6], "Exif\x00\x00")) {
+                exif_data = try allocator.alloc(u8, marker.*.data_length - 6);
+                @memcpy(exif_data.?, marker_data[6..]);
+            }
+            // XMP: starts with "http://ns.adobe.com/xap/1.0/\0"
+            else if (marker_data.len > 29 and std.mem.startsWith(u8, marker_data, "http://ns.adobe.com/xap/1.0/\x00")) {
+                xmp_data = try allocator.alloc(u8, marker.*.data_length - 29);
+                @memcpy(xmp_data.?, marker_data[29..]);
+            }
+        }
+    }
 
     if (cinfo.num_components == 1)
         cinfo.out_color_space = c.JCS_GRAYSCALE
@@ -259,6 +282,8 @@ pub fn loadJPEG(allocator: std.mem.Allocator, path: []const u8) !Image {
     errdefer {
         allocator.free(out_buf);
         if (icc_profile) |icc| allocator.free(icc);
+        if (exif_data) |exif| allocator.free(exif);
+        if (xmp_data) |xmp| allocator.free(xmp);
     }
 
     const row_buf = try allocator.alloc(u8, row_stride);
@@ -268,6 +293,8 @@ pub fn loadJPEG(allocator: std.mem.Allocator, path: []const u8) !Image {
         var row_pointers: [1][*c]u8 = .{row_buf.ptr};
         if (c.jpeg_read_scanlines(&cinfo, &row_pointers, 1) != 1) {
             if (icc_profile) |icc| allocator.free(icc);
+            if (exif_data) |exif| allocator.free(exif);
+            if (xmp_data) |xmp| allocator.free(xmp);
             return error.JPEGReadScanlinesFailed;
         }
         @memcpy(out_buf[y * row_stride .. (y + 1) * row_stride], row_buf);
@@ -275,6 +302,8 @@ pub fn loadJPEG(allocator: std.mem.Allocator, path: []const u8) !Image {
 
     if (c.jpeg_finish_decompress(&cinfo) != c.TRUE) {
         if (icc_profile) |icc| allocator.free(icc);
+        if (exif_data) |exif| allocator.free(exif);
+        if (xmp_data) |xmp| allocator.free(xmp);
         return error.JPEGFinishDecompressFailed;
     }
 
@@ -285,6 +314,8 @@ pub fn loadJPEG(allocator: std.mem.Allocator, path: []const u8) !Image {
         .hbd = false,
         .data = out_buf,
         .icc = icc_profile,
+        .exif = exif_data,
+        .xmp = xmp_data,
     };
 }
 
@@ -333,13 +364,76 @@ pub fn loadPNG(allocator: std.mem.Allocator, path: []const u8) !Image {
     if (c.spng_decoded_image_size(ctx, fmt, &out_size) != 0) return error.ImageSizeFailed;
 
     const out_buf = try allocator.alloc(u8, out_size);
-    errdefer allocator.free(out_buf);
+    errdefer {
+        allocator.free(out_buf);
+        if (icc_profile) |icc| allocator.free(icc);
+    }
 
     if (c.spng_decode_image(ctx, out_buf.ptr, out_size, fmt, 0) != 0) {
         if (icc_profile) |icc| allocator.free(icc);
         return error.DecodeFailed;
     }
 
+    var exif_data: ?[]u8 = null;
+    var png_exif: c.struct_spng_exif = undefined;
+    const exif_result = c.spng_get_exif(ctx, &png_exif);
+    print("[PNG] spng_get_exif result: {}\n", .{exif_result});
+    if (exif_result == 0) {
+        print("[PNG] EXIF length: {}, data ptr: {}\n", .{ png_exif.length, @intFromPtr(png_exif.data) });
+        if (png_exif.length > 0 and png_exif.data != null) {
+            exif_data = try allocator.alloc(u8, png_exif.length);
+            errdefer allocator.free(exif_data.?);
+            @memcpy(exif_data.?, png_exif.data[0..png_exif.length]);
+            print("[PNG] Extracted EXIF: {} bytes\n", .{png_exif.length});
+        }
+    } else if (exif_result != 73) { // 73 = SPNG_ECHUNKAVAIL chunk not present
+        print("[PNG] EXIF extraction error: {}\n", .{exif_result});
+    }
+
+    var xmp_data: ?[]u8 = null;
+
+    var n_text: u32 = 0;
+    var text_result = c.spng_get_text(ctx, null, &n_text);
+    print("[PNG] spng_get_text (count) result: {}, n_text: {}\n", .{ text_result, n_text });
+
+    if (text_result == 0 and n_text > 0) {
+        print("[PNG] Found {} text chunks, searching for XMP...\n", .{n_text});
+
+        const text_chunks = try allocator.alloc(c.struct_spng_text, n_text);
+        defer allocator.free(text_chunks);
+
+        text_result = c.spng_get_text(ctx, text_chunks.ptr, &n_text);
+        print("[PNG] spng_get_text (retrieve) result: {}\n", .{text_result});
+
+        if (text_result == 0) {
+            for (text_chunks[0..n_text], 0..) |text_chunk, i| {
+                print("[PNG] Chunk {}: type={}, ", .{ i, text_chunk.type });
+
+                const keyword_len = std.mem.indexOfScalar(u8, &text_chunk.keyword, 0) orelse text_chunk.keyword.len;
+                const keyword = text_chunk.keyword[0..keyword_len];
+                print("keyword='{s}'\n", .{keyword});
+
+                if (text_chunk.type == c.SPNG_ITXT) {
+                    if (std.mem.eql(u8, keyword, "XML:com.adobe.xmp")) {
+                        const text_len = std.mem.len(text_chunk.text);
+                        print("[PNG] Found XMP in iTXt chunk! Length: {}\n", .{text_len});
+                        if (text_len > 0) {
+                            xmp_data = try allocator.alloc(u8, text_len);
+                            errdefer allocator.free(xmp_data.?);
+                            @memcpy(xmp_data.?, text_chunk.text[0..text_len]);
+                            print("[PNG] Extracted XMP: {} bytes\n", .{text_len});
+                        }
+                        break;
+                    }
+                }
+            }
+            if (xmp_data == null) {
+                print("[PNG] No XMP found in any iTXt chunk\n", .{});
+            }
+        }
+    } else if (text_result != 73) { // 73 = SPNG_ECHUNKAVAIL
+        print("[PNG] Text chunk extraction error: {}\n", .{text_result});
+    }
     const channels: u8 = if (is_16bit) 4 else switch (fmt) {
         c.SPNG_FMT_RGB8 => 3,
         else => 4,
@@ -352,6 +446,8 @@ pub fn loadPNG(allocator: std.mem.Allocator, path: []const u8) !Image {
         .hbd = is_16bit,
         .data = out_buf,
         .icc = icc_profile,
+        .exif = exif_data,
+        .xmp = xmp_data,
     };
 }
 
@@ -451,6 +547,8 @@ pub fn loadPAM(allocator: std.mem.Allocator, path: []const u8) !Image {
         .hbd = false,
         .data = out,
         .icc = null,
+        .exif = null, // pam does not support metadata
+        .xmp = null,
     };
 }
 
@@ -461,6 +559,44 @@ pub fn loadWebP(allocator: std.mem.Allocator, path: []const u8) !Image {
     const buf = try allocator.alloc(u8, size);
     defer allocator.free(buf);
     _ = try file.readAll(buf);
+
+    var webp_data = c.WebPData{
+        .bytes = buf.ptr,
+        .size = buf.len,
+    };
+
+    var icc_profile: ?[]u8 = null;
+    var exif_data: ?[]u8 = null;
+    var xmp_data: ?[]u8 = null;
+
+    const mux = c.WebPMuxCreate(&webp_data, 0);
+    if (mux != null) {
+        defer c.WebPMuxDelete(mux);
+
+        var icc_chunk: c.WebPData = undefined;
+        if (c.WebPMuxGetChunk(mux, "ICCP", &icc_chunk) == c.WEBP_MUX_OK) {
+            if (icc_chunk.size > 0 and icc_chunk.bytes != null) {
+                icc_profile = try allocator.alloc(u8, icc_chunk.size);
+                @memcpy(icc_profile.?, icc_chunk.bytes[0..icc_chunk.size]);
+            }
+        }
+
+        var exif_chunk: c.WebPData = undefined;
+        if (c.WebPMuxGetChunk(mux, "EXIF", &exif_chunk) == c.WEBP_MUX_OK) {
+            if (exif_chunk.size > 0 and exif_chunk.bytes != null) {
+                exif_data = try allocator.alloc(u8, exif_chunk.size);
+                @memcpy(exif_data.?, exif_chunk.bytes[0..exif_chunk.size]);
+            }
+        }
+
+        var xmp_chunk: c.WebPData = undefined;
+        if (c.WebPMuxGetChunk(mux, "XMP ", &xmp_chunk) == c.WEBP_MUX_OK) {
+            if (xmp_chunk.size > 0 and xmp_chunk.bytes != null) {
+                xmp_data = try allocator.alloc(u8, xmp_chunk.size);
+                @memcpy(xmp_data.?, xmp_chunk.bytes[0..xmp_chunk.size]);
+            }
+        }
+    }
 
     var features: c.WebPBitstreamFeatures = undefined;
     if (c.WebPGetFeatures(buf.ptr, buf.len, &features) != c.VP8_STATUS_OK)
@@ -480,7 +616,12 @@ pub fn loadWebP(allocator: std.mem.Allocator, path: []const u8) !Image {
 
     const out_size = @as(usize, @intCast(width)) * @as(usize, @intCast(height)) * channels;
     const out_buf = try allocator.alloc(u8, out_size);
-    errdefer allocator.free(out_buf);
+    errdefer {
+        allocator.free(out_buf);
+        if (icc_profile) |icc| allocator.free(icc);
+        if (exif_data) |exif| allocator.free(exif);
+        if (xmp_data) |xmp| allocator.free(xmp);
+    }
     @memcpy(out_buf, @as([*]const u8, @ptrCast(data))[0..out_size]);
 
     return .{
@@ -489,7 +630,9 @@ pub fn loadWebP(allocator: std.mem.Allocator, path: []const u8) !Image {
         .channels = channels,
         .hbd = false,
         .data = out_buf,
-        .icc = null,
+        .icc = icc_profile,
+        .exif = exif_data,
+        .xmp = xmp_data,
     };
 }
 
@@ -549,6 +692,47 @@ pub fn loadHEIF(allocator: std.mem.Allocator, path: []const u8) !Image {
         }
     }
 
+    var exif_data: ?[]u8 = null;
+    var xmp_data: ?[]u8 = null;
+    const num_metadata = c.heif_image_handle_get_number_of_metadata_blocks(handle, null);
+    if (num_metadata > 0) {
+        const meta_ids = try allocator.alloc(c.heif_item_id, @intCast(num_metadata));
+        defer allocator.free(meta_ids);
+        _ = c.heif_image_handle_get_list_of_metadata_block_IDs(handle, null, meta_ids.ptr, @intCast(num_metadata));
+
+        for (meta_ids) |meta_id| {
+            const meta_type_ptr = c.heif_image_handle_get_metadata_type(handle, meta_id);
+            if (meta_type_ptr != null) {
+                const meta_type = std.mem.span(meta_type_ptr);
+                if (std.mem.eql(u8, meta_type, "Exif")) {
+                    const exif_size = c.heif_image_handle_get_metadata_size(handle, meta_id);
+                    if (exif_size > 0) {
+                        exif_data = try allocator.alloc(u8, exif_size);
+                        const err_exif = c.heif_image_handle_get_metadata(handle, meta_id, exif_data.?.ptr);
+                        if (err_exif.code != 0) {
+                            allocator.free(exif_data.?);
+                            exif_data = null;
+                        } else {
+                            print("[HEIF] Extracted EXIF: {} bytes\n", .{exif_size});
+                        }
+                    }
+                } else if (std.mem.eql(u8, meta_type, "XMP")) {
+                    const xmp_size = c.heif_image_handle_get_metadata_size(handle, meta_id);
+                    if (xmp_size > 0) {
+                        xmp_data = try allocator.alloc(u8, xmp_size);
+                        const err_xmp = c.heif_image_handle_get_metadata(handle, meta_id, xmp_data.?.ptr);
+                        if (err_xmp.code != 0) {
+                            allocator.free(xmp_data.?);
+                            xmp_data = null;
+                        } else {
+                            print("[HEIF] Extracted XMP: {} bytes\n", .{xmp_size});
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     var stride: c_int = 0;
     const plane_data = c.heif_image_get_plane_readonly(img, c.heif_channel_interleaved, &stride);
 
@@ -560,6 +744,8 @@ pub fn loadHEIF(allocator: std.mem.Allocator, path: []const u8) !Image {
     errdefer {
         allocator.free(out_buf);
         if (icc_profile) |icc| allocator.free(icc);
+        if (exif_data) |exif| allocator.free(exif);
+        if (xmp_data) |xmp| allocator.free(xmp);
     }
 
     for (0..height) |y| {
@@ -575,6 +761,8 @@ pub fn loadHEIF(allocator: std.mem.Allocator, path: []const u8) !Image {
         .hbd = is_16bit,
         .data = out_buf,
         .icc = icc_profile,
+        .exif = exif_data,
+        .xmp = xmp_data,
     };
 }
 
@@ -653,6 +841,18 @@ pub fn loadAVIF(allocator: std.mem.Allocator, path: []const u8) !Image {
         @memcpy(icc_profile.?, img_ptr.*.icc.data[0..img_ptr.*.icc.size]);
     }
 
+    var exif_data: ?[]u8 = null;
+    if (img_ptr.*.exif.size > 0 and img_ptr.*.exif.data != null) {
+        exif_data = try allocator.alloc(u8, img_ptr.*.exif.size);
+        @memcpy(exif_data.?, img_ptr.*.exif.data[0..img_ptr.*.exif.size]);
+    }
+
+    var xmp_data: ?[]u8 = null;
+    if (img_ptr.*.xmp.size > 0 and img_ptr.*.xmp.data != null) {
+        xmp_data = try allocator.alloc(u8, img_ptr.*.xmp.size);
+        @memcpy(xmp_data.?, img_ptr.*.xmp.data[0..img_ptr.*.xmp.size]);
+    }
+
     const out_buf = try copyRgbPixels(allocator, result.rgb, width, height);
     errdefer allocator.free(out_buf);
 
@@ -672,6 +872,8 @@ pub fn loadAVIF(allocator: std.mem.Allocator, path: []const u8) !Image {
         .hbd = hbd,
         .data = out_buf,
         .icc = icc_profile,
+        .exif = exif_data,
+        .xmp = xmp_data,
     };
 }
 
@@ -691,6 +893,16 @@ pub fn encodeAvifToBuffer(e: *EncCtx, allocator: std.mem.Allocator, output: *std
         const result = c.avifImageSetProfileICC(image, icc.ptr, icc.len);
         if (result != c.AVIF_RESULT_OK)
             return error.SetICCProfileFailed;
+    }
+
+    if (e.src.exif) |exif| {
+        const result = c.avifImageSetMetadataExif(image, exif.ptr, exif.len);
+        if (result != c.AVIF_RESULT_OK)
+            return error.SetExifFailed;
+
+        // restore orientation instead of using the source's
+        image.*.transformFlags = c.AVIF_TRANSFORM_NONE;
+        image.*.imir.axis = 0;
     }
 
     var rgb_img = c.avifRGBImage{};
@@ -758,6 +970,12 @@ pub fn encodeAvifToBuffer(e: *EncCtx, allocator: std.mem.Allocator, output: *std
 
     avifenc.*.quality = @intCast(e.q);
     avifenc.*.qualityAlpha = @intCast(o.quality_alpha);
+
+    if (e.src.xmp) |xmp| {
+        const result = c.avifImageSetMetadataXMP(image, xmp.ptr, xmp.len);
+        if (result != c.AVIF_RESULT_OK)
+            return error.SetXmpFailed;
+    }
 
     var avif_output = c.avifRWData{ .data = null, .size = 0 };
     if (c.avifEncoderAddImage(avifenc, image, 1, c.AVIF_ADD_IMAGE_FLAG_SINGLE) != c.AVIF_RESULT_OK)

--- a/src/io.zig
+++ b/src/io.zig
@@ -63,6 +63,7 @@ pub const Image = struct {
         if (img.icc) |icc| allocator.free(icc);
         if (img.exif) |exif| allocator.free(exif);
         if (img.xmp) |xmp| allocator.free(xmp);
+        img.* = undefined;
     }
 
     pub fn toRGB8(img: *Image, allocator: std.mem.Allocator) ![]u8 {


### PR DESCRIPTION
Extracts Exif and XMP metadata from the original and adds it to the resulting image.

All formats except PAM since it has no metadata.

